### PR TITLE
Added id to sponsors heading to easily link it (second attempt)

### DIFF
--- a/pycones/templates/pages/home.html
+++ b/pycones/templates/pages/home.html
@@ -47,7 +47,7 @@
 
     <div class="row">
         <div class="col-xs-12">
-            <h2><i class="icon-arrow"></i> {% trans "Patrocinadores" %}</h2>
+            <h2 id="sponsors"><i class="icon-arrow"></i> {% trans "Patrocinadores" %}</h2>
             {% sponsor_levels as levels %}
             {% for level in levels %}
                 {% sponsors level.pk as sponsors %}


### PR DESCRIPTION
This way this link refers firectly to the "sponsors" section:

http://2015.es.pycon.org/#sponsors

@python-spain/pycones-2015

And I promise that I looked up the right header this time.